### PR TITLE
Now using sprintf to error log instead of printf

### DIFF
--- a/pmpro-recurring-emails.php
+++ b/pmpro-recurring-emails.php
@@ -248,7 +248,9 @@ function pmpror_recurring_emails() {
 						$pmproemail->sendEmail();
 
 						//notify script
-						printf( __( "Membership renewing email sent to %s.<br />", "pmpro" ), $euser->user_email );
+						if ( WP_DEBUG ) {
+							error_log( sprintf( __( "Membership renewing email sent to %s.<br />", "pmpro" ), $euser->user_email ) );
+						}
 
 						//remember so we don't send twice
 						$sent_emails[] = $euser->ID;
@@ -261,7 +263,9 @@ function pmpror_recurring_emails() {
 
 				} else {
 					//shouldn't get here, but if no order found, just continue
-					printf( __( "Couldn't find the last order for %s.", "pmpro" ), $euser->user_email );
+					if ( WP_DEBUG ) {
+						error_log( sprintf( __( "Couldn't find the last order for %s.", "pmpro" ), $euser->user_email ) );
+					}
 				}
 			}
 


### PR DESCRIPTION
A customer was experiencing an issue on their website (PHP v7.4.30) where the `pmpro_recurring_notice_{$d}` usermeta was sometimes not being set after a recurring notice email was sent to the user. This caused the user to be emailed every time that the cron run. As I was not able to replicate this behavior on my staging website, I looked into this issue directly on their website.

In order to test this, I temporarily modified the PMPro plugin to send all `membership_recurring` emails to my personal email address to avoid spamming their customers during testing.

From there, I found that commenting out the call to `wp_mail()` for `membership_recurring` emails in the PMPro plugin caused the user meta to be saved successfully. This is strange. I later found that commenting out the call to `printf()` after the email send also caused the user meta to be saved. To rule out a timeout issue, I tried swapping the `printf()` call with `sleep(20)`, but the usermeta was still saved.

So in summary, this seems to be some weird interaction between `wp_mail()`, `printf()`, and `update_user_meta()`. Switching `printf()` to `error_log( sprint() )` did seem to fix the issue though, which is the solution that I am proposing here.