### PR TITLE
Ensure that next payment date meta matches subscription

### DIFF
--- a/pmpro-recurring-emails.php
+++ b/pmpro-recurring-emails.php
@@ -137,7 +137,7 @@ function pmpror_recurring_emails() {
 			if ( empty( $user ) ) {
 				// No user. Let's log an error, update the metadata for the subscription and continue.
 				pmpror_log( 'No user found for subscription ID ' . $subscription_obj->get_id() . ' and user ID ' . $subscription_obj->get_user_id() );
-				update_pmpro_subscription_meta( $subscription_obj->get_id(), 'pmprorm_last_next_payment_date', $subscription_obj->get_next_payment_date( 'Y-m-d H:i:s', false ) );
+				update_pmpro_subscription_meta( $subscription_obj->get_id(), 'pmprorm_last_next_payment_date', $subscription_to_notify->next_payment_date );
 				update_pmpro_subscription_meta( $subscription_obj->get_id(), 'pmprorm_last_days', $days );
 				continue;
 			}
@@ -179,7 +179,7 @@ function pmpror_recurring_emails() {
 				pmpror_log( 'Sent reminder email to user ID ' . $subscription_obj->get_user_id() );
 
 				// Update the subscription meta to prevent duplicate emails.
-				update_pmpro_subscription_meta( $subscription_obj->get_id(), 'pmprorm_last_next_payment_date', $subscription_obj->get_next_payment_date( 'Y-m-d H:i:s', false ) );
+				update_pmpro_subscription_meta( $subscription_obj->get_id(), 'pmprorm_last_next_payment_date', $subscription_to_notify->next_payment_date );
 				update_pmpro_subscription_meta( $subscription_obj->get_id(), 'pmprorm_last_days', $days );
 			} else {
 				// If we're not actually sending, log the email that we would have sent.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-lock-membership-level/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-lock-membership-level/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If the "next payment date" in subscription meta does not exactly match the subscription's next payment date, emails will be sent to users every hour. This sometimes seems to happen due to timezone issues. The PR here avoids those timezone issues and makes sure that the two timestamps always exactly match.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
